### PR TITLE
[ci] Add Semantic Release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,7 @@ env:
 
 jobs:
   linux:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -29,9 +27,7 @@ jobs:
         path: target/release/scrappy
 
   windows:
-
     runs-on: windows-2019
-
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -43,3 +39,24 @@ jobs:
         with:
           name: scrappy-windows.exe
           path: target/release/scrappy.exe
+  
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - windows
+      - linux
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          path: .binaries/
+      - name: Do Release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          semantic_version: 17.1.1
+          dry_run: ${{ github.ref != 'refs/heads/master' }}
+          extra_plugins: |
+            @google/semantic-release-replace-plugin
+            @semantic-release/git

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,33 @@
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - preset: ember
+      releaseRules:
+        - breaking: true
+          release: major
+        - revert: true
+          release: patch
+        - type: docs
+          scope: README
+          release: false
+        - type: refactor
+          scope: core-*
+          release: minor
+        - type: refactor
+          release: patch
+        - type: style
+          release: patch
+  - - "@semantic-release/release-notes-generator"
+    - preset: ember
+  - - "@google/semantic-release-replace-plugin"
+    - files: ["cargo.toml"]
+      from: "version = \".*\""
+      to: "version = \"${nextRelease.version}\""
+      results:
+        - file: "cargo.toml"
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
+  - - "@semantic-release/git"
+    - assets: ["cargo.toml"]
+  - - "@semantic-release/github"
+    - assets: .binaries/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # scrappy
+
 A small, crappy text editor. Maybe it'll grow up to be a real boy.
 
-# Current features
-It can manipulate the clipboard, read and write files, and has an about screen.
+# Project state
 
-# Upcoming features
-I don't want to write anything here, it's just guaranteed to become out-of-date. Check the issues and milestones.
+Currently, scrappy can manipulate the clipboard, read and write files, and has
+an about screen.
+
+This project uses a variation of Semantic Versioning. Versions below 1.0 do not
+track breaking changes. There will be a system for automatically identifying
+breaking changes before this project hits 1.0, but it isn't here yet.
+
+For latest information on known issues, future features, and work in progress,
+check the Issues, Milestones, Pull Requests, and Projects sections of this
+github repo.
 
 # Why should I use this editor?
+
 If you have to ask, you probably shouldn't.


### PR DESCRIPTION
Add `.releaserc`, update README, and create Github Action to invoke
Semantic Release with Ember conventions.

Fixes #5 